### PR TITLE
Add Express server with basic test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Run install script
+        run: |
+          chmod +x ./install.sh
+          ./install.sh
+      - name: Run tests
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # production-retail-and-wholesale
 Supports production, sales, billing and inventory management
+
+## Implementation Plan
+
+1. **Define Scope and Requirements**
+   - Inventory tracking for items and batches across the production unit and retail shop.
+   - Production workflow management to track raw materials and manufacturing batches.
+   - Sales management with invoices and receipts.
+   - GST-compliant accounting and tax calculations.
+   - Wholesale and retail pricing with discount handling.
+   - Movement of products between production and retail locations, plus warranty/repair tracking.
+2. **Select Technology Stack**
+   - Node.js with Express for building REST APIs.
+   - MIT License for open-source distribution.
+3. **Database Design**
+   - Tables/collections for products, production batches, inventory locations, customers, invoices, payments, discounts and GST rates.
+   - Movement tracking for stock transfers and support for wholesale vs. retail pricing tiers.
+4. **API Design**
+   - REST endpoints for products, production, inventory movement and sales.
+   - GST calculations within invoices.
+   - Authentication and authorization (e.g., OAuth2 or JWT).
+   - User management APIs for future enablement of admin, sales and production staff accounts.
+5. **Implementation Steps**
+   - Build endpoints incrementally with unit tests for GST and discount logic.
+   - Provide sample scripts or a minimal UI for demonstration.
+6. **Testing and QA**
+   - Automated tests for endpoints and workflows: production completion, inventory transfer and sales invoices.
+   - Validate GST and discount calculations.
+7. **Deployment**
+   - Offer open-source deployment scripts so the system can be run easily in various environments.

--- a/install.SH
+++ b/install.SH
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+cd server
+npm install
+npm run start &
+cd ..

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/server"
+npm install
+npm run start &
+cd - >/dev/null

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "production-retail-and-wholesale",
+  "name": "production-root",
   "version": "1.0.0",
-  "description": "Root project",
-  "private": true,
+  "license": "MIT",
   "scripts": {
     "test": "cd server && npm test"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "production-retail-and-wholesale",
+  "version": "1.0.0",
+  "description": "Root project",
+  "private": true,
+  "scripts": {
+    "test": "cd server && npm test"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "production-root",
+  "name": "production-retail-and-wholesale",
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "test": "cd server && npm test"
+    "test": "npm run test --prefix server"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+module.exports = app;

--- a/server/index.js
+++ b/server/index.js
@@ -6,10 +6,8 @@ app.get('/', (req, res) => {
   res.json({ status: 'ok' });
 });
 
-if (require.main === module) {
-  app.listen(port, () => {
-    console.log(`Server listening on port ${port}`);
-  });
-}
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});
 
 module.exports = app;

--- a/server/index.js
+++ b/server/index.js
@@ -6,8 +6,10 @@ app.get('/', (req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.listen(port, () => {
-  console.log(`Server listening on port ${port}`);
-});
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
 
 module.exports = app;

--- a/server/index.test.js
+++ b/server/index.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('./index');
+
+describe('GET /', () => {
+  it('should respond with status ok', async () => {
+    const res = await request(app).get('/');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,18 +1,17 @@
 {
-  "name": "production-retail-and-wholesale-server",
+  "name": "production-retail-server",
   "version": "1.0.0",
-  "description": "Minimal Express server",
-  "main": "server.js",
+  "description": "Minimal REST API server",
+  "main": "index.js",
   "scripts": {
-    "start": "node server.js",
+    "start": "node index.js",
     "test": "jest"
   },
-  "license": "MIT",
   "dependencies": {
     "express": "^4.18.2"
   },
   "devDependencies": {
-    "jest": "^29.0.0",
-    "supertest": "^6.0.0"
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "production-retail-and-wholesale-server",
+  "version": "1.0.0",
+  "description": "Minimal Express server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "jest"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "supertest": "^6.0.0"
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,14 +1,13 @@
 {
-  "name": "production-server",
+  "name": "server",
   "version": "1.0.0",
   "main": "index.js",
-  "license": "MIT",
   "scripts": {
     "start": "node index.js",
     "test": "jest"
   },
   "dependencies": {
-    "express": "^4.18.0"
+    "express": "^4.18.2"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "production-retail-server",
+  "name": "production-server",
   "version": "1.0.0",
-  "description": "Minimal REST API server",
   "main": "index.js",
+  "license": "MIT",
   "scripts": {
     "start": "node index.js",
     "test": "jest"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,16 @@
+const express = require('express');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/server/test/app.test.js
+++ b/server/test/app.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('GET /', () => {
+  it('responds with status ok', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/server/test/server.test.js
+++ b/server/test/server.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('GET /', () => {
+  it('responds with status ok', async () => {
+    const res = await request(app).get('/');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/server/tests/get.test.js
+++ b/server/tests/get.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('GET /', () => {
+  it('responds with status ok', async () => {
+    const res = await request(app).get('/');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});


### PR DESCRIPTION
## Summary
- add basic Express server and package manifest
- set up Jest and Supertest for integration testing
- include a simple integration test for the root GET route
- expose `test` script in `package.json`

## Testing
- `npm test` *(fails: jest not found)*