### PR TITLE
Add docker-based CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,11 @@ on:
   pull_request:
 
 jobs:
-  build-and-test:
+  docker-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-          cache: 'npm'
-      - name: Run install script
-        run: |
-          chmod +x ./install.sh
-          ./install.sh
-      - name: Run tests
-        run: npm run test
+      - name: Build Docker image
+        run: docker build -t server-test ./server
+      - name: Run tests in container
+        run: docker run --rm server-test npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+server/node_modules/
+backup/*
+!backup/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+IMAGE=production-server
+COMPOSE=docker compose
+
+build:
+$(COMPOSE) build
+
+up: build
+$(COMPOSE) up -d
+
+stop:
+$(COMPOSE) down
+
+backup:
+$(COMPOSE) exec db pg_dump -U app app > backup/dump.sql
+
+restore:
+$(COMPOSE) exec -T db psql -U app app < backup/dump.sql
+
+logs:
+$(COMPOSE) logs -f
+
+.PHONY: build up stop backup restore logs

--- a/README.md
+++ b/README.md
@@ -33,3 +33,29 @@ Supports production, sales, billing and inventory management
 ## Provisioning
 
 Run `./install.sh` to install dependencies, apply database migrations (if `DATABASE_URL` is set) and start the server.
+
+## Docker Deployment
+
+The repository includes a `Dockerfile` for the server and a `docker-compose.yml`
+that starts both the server and a PostgreSQL database. The database persists
+its data in the `db-data` volume and automatically restores from `backup/dump.sql`
+if present. When the database container stops, it exports the data back to this
+file.
+
+Use the provided `Makefile` targets to manage the environment:
+
+```
+make up       # build images and start containers in the background
+make stop     # stop containers
+make backup   # manually backup the database to backup/dump.sql
+make restore  # restore the database from backup/dump.sql
+make logs     # follow container logs
+```
+
+The server will be available on `http://localhost:3000` once started.
+
+## Continuous Integration
+
+GitHub Actions builds the Docker image defined in `server/Dockerfile` and runs
+the test suite inside that container. See `.github/workflows/ci.yml` for the
+workflow configuration.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:14
+    environment:
+      POSTGRES_DB: app
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - db-data:/var/lib/postgresql/data
+      - ./backup:/backup
+      - ./server/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
+      - ./docker/db-entrypoint.sh:/usr/local/bin/db-entrypoint.sh:ro
+    entrypoint: ["/usr/local/bin/db-entrypoint.sh"]
+    restart: always
+  server:
+    build: ./server
+    environment:
+      DATABASE_URL: postgres://app:secret@db:5432/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+volumes:
+  db-data:

--- a/docker/db-entrypoint.sh
+++ b/docker/db-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+DUMP_FILE=/backup/dump.sql
+if [ -f "$DUMP_FILE" ]; then
+  echo "Restoring database from $DUMP_FILE"
+  psql -U "$POSTGRES_USER" "$POSTGRES_DB" < "$DUMP_FILE"
+fi
+backup() {
+  pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" > "$DUMP_FILE"
+  echo "Database backed up to $DUMP_FILE"
+}
+trap backup SIGTERM SIGINT
+exec /usr/local/bin/docker-entrypoint.sh postgres

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json ./
+# Install all dependencies including devDependencies so the image
+# can be used to run tests in CI
+RUN npm ci
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- install dev dependencies in server Dockerfile
- update CI workflow to build and test using Docker
- document CI workflow in README

## Testing
- `npm test` *(fails: jest not found)*
- `docker build` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684029d392688331b0dad25d90e65f77