### PR TITLE
Add Docker Make tasks and fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 COMPOSE=docker compose -f server/docker-compose.yml
 
-.PHONY: build up down logs test
+.PHONY: build up down logs test migrate db-init backup restore
 
 build:
 	$(COMPOSE) build
@@ -17,3 +17,15 @@ logs:
 test: up
 	$(COMPOSE) exec server npm test
 	$(MAKE) down
+
+migrate:
+	$(COMPOSE) exec server bash ./script/migrate.sh
+
+db-init:
+	$(COMPOSE) exec server bash ./script/db.sh
+
+backup:
+	$(COMPOSE) exec db pg_dump -U postgres -d app > server/backup/manual_backup.sql
+
+restore:
+	cat server/backup/manual_backup.sql | $(COMPOSE) exec -T db psql -U postgres -d app

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:18
 WORKDIR /app
-COPY package*.json ./
-RUN npm install --production
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm ci --production
 COPY . .
 CMD ["npm", "run", "start"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,6 +2,7 @@ FROM node:18
 WORKDIR /app
 COPY package.json ./
 COPY package-lock.json ./
-RUN npm ci --production
+# Install all dependencies so test tools like Jest are available
+RUN npm ci
 COPY . .
 CMD ["npm", "run", "start"]

--- a/server/README.md
+++ b/server/README.md
@@ -25,3 +25,18 @@ This plan complements the high-level project plan in the repository root and gui
 
 ## Database Migrations
 Run ./script/migrate.sh after setting the DATABASE_URL environment variable to apply schema updates.
+
+## Docker Usage
+
+The `Dockerfile` and `docker-compose.yml` in this folder provide a simple way to run the server with PostgreSQL. Common tasks are wrapped in the repository root `Makefile`:
+
+```bash
+make build    # build images
+make up       # start containers in the background
+make down     # stop the stack
+make migrate  # apply database migrations
+make backup   # dump the database to backup/manual_backup.sql
+make restore  # restore the dump into the running database
+```
+
+The database container automatically imports a previous dump on startup and exports a fresh one on shutdown via `db-entrypoint.sh`.

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+# Docker Compose v2 no longer requires a version field
 services:
   db:
     image: postgres:15


### PR DESCRIPTION
## Summary
- refine server Dockerfile to copy lockfile and use `npm ci`
- extend Makefile with migrate, db-init, backup and restore helpers
- document Docker usage in `server/README.md`

## Testing
- `make test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6842e215c7bc8331ae7f45bfc122d8ab